### PR TITLE
Fix for entry point -> input matching

### DIFF
--- a/src/com/google/javascript/jscomp/Compiler.java
+++ b/src/com/google/javascript/jscomp/Compiler.java
@@ -1934,7 +1934,8 @@ public class Compiler extends AbstractCompiler implements ErrorHandler, SourceFi
       }
     }
     for (ModuleIdentifier moduleIdentifier : options.getDependencyOptions().getEntryPoints()) {
-      CompilerInput input = inputsByIdentifier.get(moduleIdentifier.toString());
+      ModuleLoader.ModulePath modPath = this.moduleLoader.resolve(moduleIdentifier.getName());
+      CompilerInput input = inputsByIdentifier.get(ModuleIdentifier.forFile(modPath.toString()).toString());
       if (input != null) {
         entryPoints.add(input);
       }


### PR DESCRIPTION
Fix for entry point to input resolution regression on #2641.

/cc @alexeagle

The issue is reproducible on https://github.com/angular/closure-demo by pointing package.json to a closure compiler built from the #2641 commit:

```
    "closure": "java -jar <path to compiler>/compiler.jar --flagfile closure.conf",
```

In short, the build fails with the current closure configuration in closure-demo repo (closure.conf):

```
--js built/**.js
--js_module_root=built

--entry_point=./built/src/bootstrap
```

The input `built/src/bootstrap.js` resolves in closure to `module$$src$$bootstrap` (since `built` is the js_module_root). With PR2641, it resolves the entry point `--entry_point=./built/src/bootstrap` to `module$$built$$src$$bootstrap`, which doesn't match the input. Without an entry point to analyze the dependency depths, the build completes with an invalid bundle (bundle end ups up being 100 bytes or so).

A work-around is possible in the closure conf in closure-demo to make it work:

```
--js built/**.js
--js_module_root=built

--entry_point=src/bootstrap
```

The closure compiler then correctly matches up the entry point to the input and the build works. Ideally, the build would error out if the entry point does not match an input but that doesn't happen.

With the patch in this PR, the compiler handles both `--entry_point=./built/src/bootstrap` and `--entry_point=src/bootstrap` correctly.
