### PR TITLE
RFC: visit exports during dependency tree walk

### DIFF
--- a/src/com/google/javascript/jscomp/FindModuleDependencies.java
+++ b/src/com/google/javascript/jscomp/FindModuleDependencies.java
@@ -89,12 +89,11 @@ public class FindModuleDependencies implements NodeTraversal.Callback {
         // export default
       } else if (n.getBooleanProp(Node.EXPORT_ALL_FROM)) {
         // export * from 'moduleIdentifier';
+        // not yet supported by closure ES6 transpilation: 'Wildcard export' is not yet implemented.
       } else if (n.hasTwoChildren()) {
         // export {x, y as z} from 'moduleIdentifier';
         Node moduleIdentifier = n.getLastChild();
         Node importNode = IR.importNode(IR.empty(), IR.empty(), moduleIdentifier.cloneNode());
-        importNode.useSourceInfoFrom(n);
-        parent.addChildBefore(importNode, n);
         visit(t, importNode, parent);
       }
     } else if (supportsEs6Modules && n.isImport()) {


### PR DESCRIPTION
I needed the following change for a build to work that contained exports such as:
```
export {x, y as z} from 'some-module';
```
Files referenced on lines like this were not being included in the bundle. I took a look at the Es6ModuleRewrite code and used that as an example to update FindModuleDependencies.java so that the files referenced in export lines like the one above are visited and end up included in the bundle.

I didn't handle the `export * from 'some-module'` case but that one should probably be handled as well.

Does this change make sense to you? Can something like this be included in PR #2641?
